### PR TITLE
Fix: Adicionar AuthProvider para resolver erro de tela branca

### DIFF
--- a/dashboard/frontend/src/App.jsx
+++ b/dashboard/frontend/src/App.jsx
@@ -12,10 +12,12 @@ import Layout from "./components/Layout";
 import ProtectedRoute from "./routes/ProtectedRoutes";
 import EsqueciSenhaPage from "./pages/EsqueciSenhaPage";
 import SessionTimeoutHandler from "./components/SessionTimeoutHandler";
+import { AuthProvider } from "./context/AuthContext";
 
 function App() {
   return (
-    <Router>
+    <AuthProvider>
+      <Router>
       <Routes>
         <Route path="/" element={<LoginPage />} />
         <Route path="/cadastro" element={<CadastroPage />} />
@@ -38,6 +40,7 @@ function App() {
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </Router>
+    </AuthProvider>
   );
 }
 


### PR DESCRIPTION
## Descrição

Este PR contém uma correção específica para o problema de tela branca que ocorria na aplicação.

## Correção implementada

- Adicionado o componente `AuthProvider` ao redor do `Router` no arquivo App.jsx
- Isso resolve o erro: "useAuthContext deve ser usado dentro de um AuthProvider"

Esta correção garante que o contexto de autenticação esteja disponível para todos os componentes da aplicação, evitando o erro de tela branca que ocorria quando o hook `useAuthContext` era chamado sem o provider adequado.