### PR TITLE
Correção do alinhamento entre Sidebar e Layout

### DIFF
--- a/dashboard/frontend/src/components/Layout.jsx
+++ b/dashboard/frontend/src/components/Layout.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import Sidebar from "./Sidebar";
+import { Menu } from "lucide-react";
 
 const getPageTitle = (pathname) => {
   switch (pathname) {
@@ -30,6 +31,7 @@ const Layout = () => {
   const pageTitle = getPageTitle(location.pathname);
   const [showTopbar, setShowTopbar] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   // Controle de scroll para esconder/mostrar a topbar
   useEffect(() => {
@@ -51,28 +53,35 @@ const Layout = () => {
     return () => window.removeEventListener("scroll", handleScroll);
   }, [lastScrollY]);
 
+  // Função para alternar o estado da sidebar
+  const toggleSidebar = () => {
+    setSidebarOpen(!sidebarOpen);
+  };
+
   return (
     <div className="flex h-screen bg-background">
-      <Sidebar />
+      <Sidebar open={sidebarOpen} setOpen={setSidebarOpen} />
       <div className="flex-1 flex flex-col overflow-y-auto">
-        {/* Topbar Mobile - Agora desaparece ao rolar */}
+        {/* Topbar Mobile - Agora com o botão de menu integrado */}
         <div 
-          className={`md:hidden flex items-center px-4 py-3 bg-card shadow-sm z-10 transition-transform duration-300 ${
+          className={`flex items-center px-4 py-3 bg-card shadow-sm z-10 transition-transform duration-300 ${
             showTopbar ? 'transform-none' : '-translate-y-full'
           }`}
           style={{ position: 'sticky', top: 0 }}
         >
           <div className="flex items-center w-full gap-4">
-            {/* Espaço reservado para o botão de menu que já está no Sidebar */}
-            <button className="md:hidden">
-              {/* Aqui poderia ir um ícone se quiser mover o botão para cá */}
+            {/* Botão de menu agora está aqui na topbar */}
+            <button 
+              onClick={toggleSidebar}
+              className="text-text md:hidden"
+            >
+              <Menu size={28} />
             </button>
             <h1 className="text-xl font-semibold text-text">{pageTitle}</h1>
           </div>
-
         </div>
 
-        {/* Conteúdo da página - Sem margem adicional pois a topbar não é mais fixa */}
+        {/* Conteúdo da página */}
         <main className="flex-1 px-4 py-4 md:py-6">
           <Outlet />
         </main>

--- a/dashboard/frontend/src/components/Sidebar.jsx
+++ b/dashboard/frontend/src/components/Sidebar.jsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
   LogOut,
@@ -7,13 +6,11 @@ import {
   BarChart,
   List,
   User,
-  Menu,
   X,
   Navigation,
 } from "lucide-react";
 
-const Sidebar = () => {
-  const [open, setOpen] = useState(false);
+const Sidebar = ({ open, setOpen }) => {
   const location = useLocation();
   const navigate = useNavigate();
   
@@ -34,16 +31,6 @@ const Sidebar = () => {
   
   return (
     <>
-      {/* Botão mobile de abrir menu - Agora apenas com ícone hambúrguer tradicional */}
-      <div className="md:hidden fixed top-4 left-4 z-50">
-        <button 
-          onClick={() => setOpen(true)}
-          className="text-text"
-        >
-          <Menu size={28} />
-        </button>
-      </div>
-      
       {/* Overlay ao abrir menu mobile */}
       {open && (
         <div


### PR DESCRIPTION
Este PR corrige o problema de alinhamento entre o botão do menu e o título da página, movendo o botão do menu do Sidebar para o Layout (top bar) e garantindo que ambos estejam no mesmo elemento, corretamente alinhados.