### PR TITLE
Corrigir erros de sintaxe no WorkOrderAllocation.jsx

### DIFF
--- a/dashboard/frontend/src/pages/WorkOrderAllocation.jsx
+++ b/dashboard/frontend/src/pages/WorkOrderAllocation.jsx
@@ -1064,11 +1064,6 @@ const WorkOrderAllocation = () => {
                         </button>
                       </div>
                     </div>
-                  )}         
-                          
-                        </button>
-                      </div>
-                    </div>
                   )}
                   
                   {/* Botão de mapa logo abaixo da morada */}
@@ -1145,7 +1140,8 @@ const WorkOrderAllocation = () => {
                         })()}
                       </p>
                     </div>
-                  )}            </div>
+                  )}
+                </div>
               </div>
               
               {/* Botões de ação - Nova Busca e Voltar */}


### PR DESCRIPTION
Este PR corrige dois erros de sintaxe no arquivo WorkOrderAllocation.jsx:

1. Removido tag </button> extra na linha 1069 que não correspondia à tag de abertura <div>
2. Corrigido erro de sintaxe na linha 1151 onde era esperado ")" mas foi encontrado "{"

O build foi validado localmente e está funcionando corretamente.