### PR TITLE
Adicionar função validarFormatoWO que estava faltando

### DIFF
--- a/dashboard/frontend/src/pages/WorkOrderAllocation.jsx
+++ b/dashboard/frontend/src/pages/WorkOrderAllocation.jsx
@@ -305,6 +305,11 @@ const determinarCorFibra = (corTexto, corHex) => {
   return resultado;
 };
 
+// Função para validar o formato do número da WO
+const validarFormatoWO = (numero) => {
+  return /^\d{8}$/.test(numero);
+};
+
 // Função para determinar a cor da fibra com base na dona de rede e porto primário
 const determinarCorFibraPorRegras = (donaRede, portoEntrada, fibra) => {
   // Valores padrão


### PR DESCRIPTION
Este PR adiciona a função validarFormatoWO que estava faltando no arquivo WorkOrderAllocation.jsx, causando o erro:

```
index-8wXkYH1C.js:354 Uncaught (in promise) ReferenceError: validarFormatoWO is not defined
```

A função foi implementada conforme encontrada no histórico do arquivo, validando se o número da WO contém exatamente 8 dígitos numéricos.

O build foi validado localmente e está funcionando corretamente.