### PR TITLE
Corrigir erro de autenticação após login na alocação de WO

### DIFF
--- a/dashboard/frontend/src/context/AuthContext.jsx
+++ b/dashboard/frontend/src/context/AuthContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, useEffect } from 'react';
 
 // Criar o contexto de autenticação
 const AuthContext = createContext();
@@ -27,6 +27,33 @@ export const AuthProvider = ({ children }) => {
       role: 'technician'
     };
   });
+  
+  // Efeito para sincronizar o contexto com o localStorage
+  useEffect(() => {
+    // Função para verificar e atualizar o token do localStorage
+    const checkAuthToken = () => {
+      const storedToken = localStorage.getItem('authToken');
+      if (storedToken !== authToken) {
+        setAuthToken(storedToken);
+      }
+      
+      const storedUser = localStorage.getItem('user');
+      if (storedUser) {
+        const parsedUser = JSON.parse(storedUser);
+        if (JSON.stringify(parsedUser) !== JSON.stringify(user)) {
+          setUser(parsedUser);
+        }
+      }
+    };
+    
+    // Verificar imediatamente ao montar o componente
+    checkAuthToken();
+    
+    // Opcional: verificar periodicamente para sincronização
+    const interval = setInterval(checkAuthToken, 2000);
+    
+    return () => clearInterval(interval);
+  }, [authToken, user]);
 
   // Função para login
   const login = (token, userData) => {


### PR DESCRIPTION
Este PR corrige o problema de autenticação que ocorre quando o usuário tenta alocar uma WO logo após fazer login, recebendo a mensagem "Sessão expirada. Por favor, faça login novamente".

## Causa Raiz
O problema ocorre devido à falta de sincronização entre o localStorage e o AuthContext. Quando o usuário faz login, o token é salvo no localStorage, mas o contexto já foi inicializado e não reage automaticamente a essa mudança.

## Solução Implementada
Adicionei um useEffect no AuthContext para monitorar e sincronizar as alterações do localStorage, garantindo que o token seja sempre atualizado mesmo após a inicialização do contexto.

A solução elimina a necessidade de recarregar a página após o login para que a alocação de WO funcione corretamente.

Detalhes completos da análise estão disponíveis no arquivo analise-erro-login.md.